### PR TITLE
Clean up 16-bit SPI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Support for 16-bit words with SPI ([#107](https://github.com/stm32-rs/stm32f3xx-hal/pull/107))
+
 ## [v0.5.0] - 2020-07-21
 
 ### Added


### PR DESCRIPTION
I cleaned up your implementation of 16-bit SPI support a bit, notably removing the need for code duplication for the `FullDuplex` impls.